### PR TITLE
Arduino Wifi Functionality

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -16,6 +16,10 @@ jobs:
          repository: adafruit/ci-arduino
          path: ci
 
+    - name: Install WiFiS3 library
+      run: |
+        arduino-cli lib install "WiFiS3"
+
     - name: pre-install
       run: bash ci/actions_install.sh
 

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -16,6 +16,11 @@ jobs:
          repository: adafruit/ci-arduino
          path: ci
 
+    - name: Install arduino-cli
+      run: |
+        curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
+        sudo mv bin/arduino-cli /usr/local/bin
+
     - name: Install WiFiS3 library
       run: |
         arduino-cli lib install "WiFiS3"

--- a/examples/Wifi/2ChannelPhaseShiftWifi/2ChannelPhaseShiftWifi.ino
+++ b/examples/Wifi/2ChannelPhaseShiftWifi/2ChannelPhaseShiftWifi.ino
@@ -1,0 +1,63 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   Two-channel sine with a fixed phase shift
+   - OUT1: sine @ FREQ_HZ, PHASE=0°
+   - OUT2: sine @ FREQ_HZ, PHASE=PHASE_DEG
+   Uses: SOUR<n>:PHAS, OUTPUT:STATE ON, SOUR:TRig:INT
+*/
+
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+// -------- User config --------
+
+const float FREQ_HZ   = 10000.0;  // both channels
+const float AMP_V     = 1.0;      // one-way amplitude
+const float OFFS_V    = 0.0;      // DC offset
+const float PHASE_DEG = 90.0;     // OUT2 phase relative to OUT1
+/* ---------------------------- */
+
+WifiSCPI rp;
+
+void startTwoSineWithPhase() {
+  rp.scpi("GEN:RST");
+
+  // Configure OUT1
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi(String("SOUR1:FREQ:FIX ") + String(FREQ_HZ, 6));
+  rp.scpi(String("SOUR1:VOLT ")     + String(AMP_V, 6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ")+ String(OFFS_V, 6));
+  rp.scpi("SOUR1:PHAS 0");
+
+  // Configure OUT2 (same freq/amp, shifted phase)
+  rp.scpi("SOUR2:FUNC SINE");
+  rp.scpi(String("SOUR2:FREQ:FIX ") + String(FREQ_HZ, 6));
+  rp.scpi(String("SOUR2:VOLT ")     + String(AMP_V, 6));
+  rp.scpi(String("SOUR2:VOLT:OFFS ")+ String(OFFS_V, 6));
+  rp.scpi(String("SOUR2:PHAS ")     + String(PHASE_DEG, 6));
+
+  rp.scpi("OUTPUT:STATE ON");
+  rp.scpi("SOUR:TRig:INT");
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  startTwoSineWithPhase();
+  Serial.println("Two-channel sine with phase shift is running.");
+}
+
+void loop() {
+  // Optional keep-alive / auto-restart
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startTwoSineWithPhase();
+  }
+  delay(500);
+}
+

--- a/examples/Wifi/2ChannelPhaseShiftWifi/arduino_secrets.h
+++ b/examples/Wifi/2ChannelPhaseShiftWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/AcquireNowRawWifi/AcquireNowRawWifi.ino
+++ b/examples/Wifi/AcquireNowRawWifi/AcquireNowRawWifi.ino
@@ -1,0 +1,46 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   acquire_full_buffer_raw: force trigger and read full buffer as RAW ASCII codes
+*/
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+
+WifiSCPI rp;
+
+void printFirst(const String& blk, uint8_t n=12){
+  int l=blk.indexOf('{'), r=blk.lastIndexOf('}');
+  if(l<0||r<=l){ Serial.println(blk); return; }
+  String b=blk.substring(l+1,r);
+  int st=0,c=0;
+  Serial.println(F("First RAW samples:"));
+  while(c<n){
+    int k=b.indexOf(',',st);
+    String t=(k==-1)?b.substring(st):b.substring(st,k);
+    t.trim();
+    if(t.length()){ Serial.println(t); c++; }
+    if(k==-1) break;
+    st=k+1;
+  }
+}
+
+void setup(){
+  Serial.begin(115200);
+  delay(200);
+  rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT);
+
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:DEC:Factor 1");
+  rp.scpi("ACQ:DATA:FORMAT ASCII");
+  rp.scpi("ACQ:DATA:UNITS RAW");   // ADC codes
+  rp.scpi("ACQ:TRig:DLY 0");
+
+  rp.scpi("ACQ:START");
+  delay(300);
+  rp.scpi("ACQ:TRig NOW");
+
+  while(rp.scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
+  printFirst(rp.scpiBlock("ACQ:SOUR1:DATA?"));
+  Serial.println("Done.");
+}
+
+void loop(){}

--- a/examples/Wifi/AcquireNowRawWifi/arduino_secrets.h
+++ b/examples/Wifi/AcquireNowRawWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/AcquireNowWifi/AcquireNowWifi.ino
+++ b/examples/Wifi/AcquireNowWifi/AcquireNowWifi.ino
@@ -1,0 +1,38 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   acquire_trigger_now: force trigger and read CH1 (ASCII/VOLTS)
+*/
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+
+WifiSCPI rp;
+
+void printFirst(const String& blk, uint8_t n=12){
+  int l=blk.indexOf('{'), r=blk.lastIndexOf('}'); if(l<0||r<=l){ Serial.println(blk); return; }
+  String b=blk.substring(l+1,r); int st=0,c=0; Serial.println(F("First samples:"));
+  while(c<n){ int k=b.indexOf(',',st); String t=(k==-1)?b.substring(st):b.substring(st,k); t.trim();
+    if(t.length()){ Serial.println(t); c++; } if(k==-1) break; st=k+1; }
+}
+
+void setup(){
+  Serial.begin(115200); delay(200);
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:DEC:Factor 128");
+  rp.scpi("ACQ:DATA:FORMAT VOLTS");
+  rp.scpi("ACQ:DATA:UNITS ASCII");
+  rp.scpi("ACQ:TRig:DLY 0");
+  rp.scpi("ACQ:START");
+  delay(300);
+  rp.scpi("ACQ:TRig NOW");
+
+  while(rp.scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
+  printFirst(rp.scpiBlock("ACQ:SOUR1:DATA?"));
+  Serial.println("Done.");
+}
+
+void loop(){ }

--- a/examples/Wifi/AcquireNowWifi/arduino_secrets.h
+++ b/examples/Wifi/AcquireNowWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/AcquireTriggerFromGenWifi/AcquireTriggerFromGenWifi.ino
+++ b/examples/Wifi/AcquireTriggerFromGenWifi/AcquireTriggerFromGenWifi.ino
@@ -1,0 +1,54 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   acquire_trigger_from_generator:
+   - start a sine on OUT1
+   - arm acquisition on AWG trigger (AWG_PE)
+   - fire generator INT trigger to produce the edge
+*/
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+
+WifiSCPI rp;
+
+void printFirst(const String& blk, uint8_t n=12){
+  int l=blk.indexOf('{'), r=blk.lastIndexOf('}'); if(l<0||r<=l){ Serial.println(blk); return; }
+  String b=blk.substring(l+1,r); int st=0,c=0; Serial.println(F("First samples:"));
+  while(c<n){ int k=b.indexOf(',',st); String t=(k==-1)?b.substring(st):b.substring(st,k); t.trim();
+    if(t.length()){ Serial.println(t); c++; } if(k==-1) break; st=k+1; }
+}
+
+void setup(){
+  Serial.begin(115200); delay(200);
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  // Generator: small sine on OUT1
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi("SOUR1:FREQ:FIX 10000");
+  rp.scpi("SOUR1:VOLT 0.5");
+  rp.scpi("SOUR1:VOLT:OFFS 0");
+  rp.scpi("OUTPUT1:STATE ON");
+
+  // Acquisition waiting for AWG trigger
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:DEC:Factor 1");
+  rp.scpi("ACQ:DATA:FORMAT VOLTS");
+  rp.scpi("ACQ:DATA:UNITS ASCII");
+  rp.scpi("ACQ:TRig:DLY 0");
+  rp.scpi("ACQ:START");
+  rp.scpi("ACQ:TRig AWG_PE");
+
+  // Fire AWG INT trigger
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
+
+  while(rp.scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
+  printFirst(rp.scpiBlock("ACQ:SOUR1:DATA?"));
+  Serial.println("Done.");
+}
+
+void loop(){ }
+

--- a/examples/Wifi/AcquireTriggerFromGenWifi/arduino_secrets.h
+++ b/examples/Wifi/AcquireTriggerFromGenWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/AnalogReadWifi/AnalogReadWifi.ino
+++ b/examples/Wifi/AnalogReadWifi/AnalogReadWifi.ino
@@ -1,0 +1,75 @@
+/*  UNO R4 WiFi → Red Pitaya (SCPI)
+    - OUT1 arbitrary waveform = sum of 3 sines
+    - Fast, chunked upload (default 2048 points)
+*/
+
+#include "wifiSCPI.h"
+#include <math.h>
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+
+int   ARB_NPTS     = 2048;
+float F0_HZ        = 1000.0;
+float AMP1 = 1.0f, AMP2 = 0.6f, AMP3 = 0.3f;
+int   K1 = 1, K2 = 2, K3 = 5;
+float P1 = 0.0f, P2 = 0.0f, P3 = 0.0f;
+float ARB_AMPL_V   = 1.0f;
+float ARB_OFFS_V   = 0.0f;
+
+WifiSCPI rp;
+
+float sum3sines_norm(int i, int N) {
+  float t = 2.0f * (float)M_PI * (float)i / (float)N;
+  float x = 0.0f;
+  x += AMP1 * sinf(K1 * t + P1);
+  x += AMP2 * sinf(K2 * t + P2);
+  x += AMP3 * sinf(K3 * t + P3);
+  float S = fabsf(AMP1) + fabsf(AMP2) + fabsf(AMP3);
+  if (S < 1e-9f) S = 1.0f;
+  x /= S;
+  if (x > 1.0f) x = 1.0f;
+  if (x < -1.0f) x = -1.0f;
+  return x;
+}
+
+bool uploadSum3SinesOut1(int N) {
+  if (!rp.connected()) return false;
+  rp.scpi("GEN:RST");
+  rp.scpi("OUTPUT1:STATE OFF");
+  rp.scpi("SOUR1:FUNC ARBITRARY");
+  rp.client().print("SOUR1:TRAC:DATA:DATA ");
+  const int chunk = 256;
+  for (int i = 0; i < N; ++i) {
+    if (i) rp.client().print(",");
+    rp.client().print(sum3sines_norm(i, N), 6);
+  }
+  rp.client().print("\r\n");
+  float freq_set = F0_HZ * (16384.0f / (float)N);
+  rp.client().print("SOUR1:FREQ:FIX ");  rp.client().print(freq_set, 6);     rp.client().print("\r\n");
+  rp.client().print("SOUR1:VOLT ");      rp.client().print(ARB_AMPL_V, 6);   rp.client().print("\r\n");
+  rp.client().print("SOUR1:VOLT:OFFS "); rp.client().print(ARB_OFFS_V, 6);   rp.client().print("\r\n");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:INT");
+  return true;
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)) {
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+  uploadSum3SinesOut1(ARB_NPTS);
+  Serial.println("Sum-of-3-sines running on OUT1.");
+}
+
+void loop() {
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) uploadSum3SinesOut1(ARB_NPTS);
+  }
+  delay(500);
+}
+

--- a/examples/Wifi/AnalogReadWifi/arduino_secrets.h
+++ b/examples/Wifi/AnalogReadWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/ArbSignalWifi/ArbSignalWifi.ino
+++ b/examples/Wifi/ArbSignalWifi/ArbSignalWifi.ino
@@ -1,0 +1,107 @@
+/*  UNO R4 WiFi → Red Pitaya (SCPI)
+    - OUT1 arbitrary waveform = sum of 3 sines
+    - Fast, chunked upload (default 2048 points)
+    - No acquisition, no LEDs — just ARB gen
+*/
+
+#include "wifiSCPI.h"
+#include <math.h>
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+/************ User Config ************/
+// Red Pitaya SCPI server
+
+// ARB buffer size (use 2048 for speed; 16384 is the full period size)
+int   ARB_NPTS     = 2048;
+
+// Base output frequency (Hz). The three tones will be
+// k1*f0, k2*f0, k3*f0 to make a seamless periodic waveform.
+float F0_HZ        = 1000.0;   // "fundamental" frequency
+
+// Amplitudes of the 3 sines (renamed to avoid conflict with A1/A2/A3 pin names)
+float AMP1 = 1.0f,  AMP2 = 0.6f,  AMP3 = 0.3f;
+
+// Harmonic bins (integers). Output tones = k*F0_HZ.
+int   K1 = 1,       K2 = 2,       K3 = 5;
+
+// Optional phases (radians)
+float P1 = 0.0f,    P2 = 0.0f,    P3 = 0.0f;
+
+// Analog output settings
+float ARB_AMPL_V   = 1.0f;     // amplitude (Volts)
+float ARB_OFFS_V   = 0.0f;     // DC offset (Volts)
+/************************************/
+
+WifiSCPI rp;
+
+/* ---------- Waveform: sum of 3 sines, normalized to [-1..+1] ---------- */
+float sum3sines_norm(int i, int N) {
+  float t = 2.0f * (float)M_PI * (float)i / (float)N;
+  float x = 0.0f;
+  x += AMP1 * sinf(K1 * t + P1);
+  x += AMP2 * sinf(K2 * t + P2);
+  x += AMP3 * sinf(K3 * t + P3);
+  float S = fabsf(AMP1) + fabsf(AMP2) + fabsf(AMP3);
+  if (S < 1e-9f) S = 1.0f;
+  x /= S;
+  if (x > 1.0f) x = 1.0f;
+  if (x < -1.0f) x = -1.0f;
+  return x;
+}
+
+/* ---------- Upload ARB (chunked), configure, and run ---------- */
+bool uploadSum3SinesOut1(int N) {
+  if (!rp.connected()) return false;
+
+  Serial.print("Uploading ARB (N="); Serial.print(N); Serial.print(") ... ");
+
+  rp.scpi("GEN:RST");
+  rp.scpi("OUTPUT1:STATE OFF");
+  rp.scpi("SOUR1:FUNC ARBITRARY");
+
+  rp.client().print("SOUR1:TRAC:DATA:DATA ");
+  const int chunk = 256;
+  for (int i = 0; i < N; ++i) {
+    if (i) rp.client().print(",");
+    rp.client().print(sum3sines_norm(i, N), 6);
+    if ((i % chunk) == 0) Serial.print(".");
+  }
+  rp.client().print("\r\n");
+  Serial.println(" done");
+
+  float freq_set = F0_HZ * (16384.0f / (float)N);
+
+  rp.client().print("SOUR1:FREQ:FIX ");  rp.client().print(freq_set, 6);     rp.client().print("\r\n");
+  rp.client().print("SOUR1:VOLT ");      rp.client().print(ARB_AMPL_V, 6);   rp.client().print("\r\n");
+  rp.client().print("SOUR1:VOLT:OFFS "); rp.client().print(ARB_OFFS_V, 6);   rp.client().print("\r\n");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:INT");
+  return true;
+}
+
+/* ---------- Arduino ---------- */
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  // Upload and start the 3-sine sum on OUT1
+  uploadSum3SinesOut1(ARB_NPTS);
+
+  Serial.println("Sum-of-3-sines running on OUT1.");
+}
+
+void loop() {
+  // Keep the link healthy (optional)
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) uploadSum3SinesOut1(ARB_NPTS); // re-arm after reconnect
+  }
+  delay(500);
+}
+

--- a/examples/Wifi/ArbSignalWifi/arduino_secrets.h
+++ b/examples/Wifi/ArbSignalWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/BurstSignalWifi/BurstSignalWifi.ino
+++ b/examples/Wifi/BurstSignalWifi/BurstSignalWifi.ino
@@ -1,0 +1,77 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   Sine burst on OUT1 using official burst commands
+
+   Flow:
+     GEN:RST
+     SOUR1:FUNC SINE
+     SOUR1:FREQ:FIX <Hz>
+     SOUR1:VOLT <V>; SOUR1:VOLT:OFFS <V>
+     SOUR1:BURS:STAT BURST
+     SOUR1:BURS:NCYC <Ncycles>
+     SOUR1:BURS:NOR  <Repetitions>   (65536 == infinite)
+     SOUR1:BURS:INT:PER <Period_us>
+     OUTPUT1:STATE ON
+     SOUR1:TRig:SOUR INT
+     SOUR1:TRig:INT
+*/
+
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+// ---------- User config ----------
+
+// Signal settings
+const float FREQ_HZ   = 10e3;       // sine frequency
+const float AMP_V     = 0.8;        // one-way amplitude (V). |AMP|+|OFFS| ≤ 1 V on most RP models
+const float OFFS_V    = 0.0;        // DC offset (V)
+
+// Burst settings
+const uint32_t NCYCLES      = 5;        // number of sine periods in one burst
+const uint32_t REPETITIONS  = 10;       // number of bursts (65536 == infinite)
+const uint32_t PERIOD_US    = 100000;   // time from start-of-burst to start-of-next (µs)
+// ----------------------------------
+
+WifiSCPI rp;
+
+void startBurst() {
+  // Reset & basic sine settings
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi(String("SOUR1:FREQ:FIX ") + String(FREQ_HZ, 6));
+  rp.scpi(String("SOUR1:VOLT ")     + String(AMP_V,   6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ")+ String(OFFS_V,  6));
+
+  // --- Burst mode (official commands) ---
+  rp.scpi("SOUR1:BURS:STAT BURST");
+  rp.scpi(String("SOUR1:BURS:NCYC ") + String(NCYCLES));
+  rp.scpi(String("SOUR1:BURS:NOR ")  + String(REPETITIONS));
+  rp.scpi(String("SOUR1:BURS:INT:PER ") + String(PERIOD_US));
+
+  // Output + trigger
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  startBurst();
+  Serial.println("Burst started on OUT1.");
+}
+
+void loop() {
+  // Optional keep-alive
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startBurst();
+  }
+  delay(500);
+}
+

--- a/examples/Wifi/BurstSignalWifi/arduino_secrets.h
+++ b/examples/Wifi/BurstSignalWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/DMAAcquireWifi/DMAAcquireNowWifi.ino
+++ b/examples/Wifi/DMAAcquireWifi/DMAAcquireNowWifi.ino
@@ -1,0 +1,53 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   dma/acquire_dma_trigger_now: set AXI DMA, trigger NOW, read 1024 samples near trig (ASCII)
+*/
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+
+WifiSCPI rp;
+
+/* helpers */
+void printFirst(const String& blk, uint8_t n=12){
+  int l=blk.indexOf('{'), r=blk.lastIndexOf('}'); if(l<0||r<=l){ Serial.println(blk); return; }
+  String b=blk.substring(l+1,r); int st=0,c=0; Serial.println(F("First DMA samples:"));
+  while(c<n){ int k=b.indexOf(',',st); String t=(k==-1)?b.substring(st):b.substring(st,k); t.trim();
+    if(t.length()){ Serial.println(t); c++; } if(k==-1) break; st=k+1; }
+}
+
+void setup(){
+  Serial.begin(115200); delay(200);
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  uint32_t axiStart = rp.scpiLine("ACQ:AXI:START?").toInt();
+  uint32_t axiSize  = rp.scpiLine("ACQ:AXI:SIZE?").toInt();
+  (void)axiStart; (void)axiSize;
+
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:AXI:DEC 1");
+  rp.scpi("ACQ:AXI:DATA:UNITS VOLTS");
+  rp.scpi("ACQ:DATA:FORMAT ASCII");
+  rp.scpi(String("ACQ:AXI:SOUR1:SET:Buffer ")+axiStart+","+axiSize);
+  rp.scpi("ACQ:AXI:SOUR1:ENable ON");
+  rp.scpi("ACQ:AXI:SOUR1:Trig:Dly 0");
+
+  rp.scpi("ACQ:START");
+  rp.scpi("ACQ:TRig NOW");
+
+  while(rp.scpiLine("ACQ:TRig:STAT?")!="TD") delay(10);
+  while(rp.scpiLine("ACQ:AXI:SOUR1:TRIG:FILL?")!="1") delay(10);
+
+  uint32_t pos = rp.scpiLine("ACQ:AXI:SOUR1:Trig:Pos?").toInt();
+  String cmd = String("ACQ:AXI:SOUR1:DATA:Start:N? ")+pos+",1024";
+  printFirst(rp.scpiBlock(cmd));
+
+  rp.scpi("ACQ:STOP");
+  rp.scpi("ACQ:AXI:SOUR1:ENable OFF");
+  Serial.println("Done.");
+}
+
+void loop(){ }
+

--- a/examples/Wifi/DMAAcquireWifi/DMAAcquireWifi.ino
+++ b/examples/Wifi/DMAAcquireWifi/DMAAcquireWifi.ino
@@ -1,0 +1,54 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   DMA acquire triggered by generator:
+   - start a sine on OUT1
+   - arm acquisition on AWG trigger (AWG_PE)
+   - fire generator INT trigger to produce the edge
+*/
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+
+WifiSCPI rp;
+
+void printFirst(const String& blk, uint8_t n=12){
+  int l=blk.indexOf('{'), r=blk.lastIndexOf('}'); if(l<0||r<=l){ Serial.println(blk); return; }
+  String b=blk.substring(l+1,r); int st=0,c=0; Serial.println(F("First samples:"));
+  while(c<n){ int k=b.indexOf(',',st); String t=(k==-1)?b.substring(st):b.substring(st,k); t.trim();
+    if(t.length()){ Serial.println(t); c++; } if(k==-1) break; st=k+1; }
+}
+
+void setup(){
+  Serial.begin(115200); delay(200);
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  // Generator: small sine on OUT1
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi("SOUR1:FREQ:FIX 10000");
+  rp.scpi("SOUR1:VOLT 0.5");
+  rp.scpi("SOUR1:VOLT:OFFS 0");
+  rp.scpi("OUTPUT1:STATE ON");
+
+  // Acquisition waiting for AWG trigger
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:DEC:Factor 1");
+  rp.scpi("ACQ:DATA:FORMAT VOLTS");
+  rp.scpi("ACQ:DATA:UNITS ASCII");
+  rp.scpi("ACQ:TRig:DLY 0");
+  rp.scpi("ACQ:START");
+  rp.scpi("ACQ:TRig AWG_PE");
+
+  // Fire AWG INT trigger
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
+
+  while(rp.scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
+  printFirst(rp.scpiBlock("ACQ:SOUR1:DATA?"));
+  Serial.println("Done.");
+}
+
+void loop(){ }
+

--- a/examples/Wifi/DMAAcquireWifi/arduino_secrets.h
+++ b/examples/Wifi/DMAAcquireWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/GPIOToggleWifi/GPIOToggleWifi.ino
+++ b/examples/Wifi/GPIOToggleWifi/GPIOToggleWifi.ino
@@ -1,0 +1,39 @@
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+WifiSCPI rp;
+
+void setup() {
+  Serial.begin(115200);
+
+  // Connect to WiFi and Red Pitaya
+  rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT);
+
+  // Configure DIO0_P as OUTPUT
+  rp.scpi("DIG:PIN:DIR DIO0_P,OUT");
+
+  // Configure DIO1_P as INPUT
+  rp.scpi("DIG:PIN:DIR DIO1_P,IN");
+
+  Serial.println("Setup done. Toggling DIO0_P and reading DIO1_P...");
+}
+
+void loop() {
+  // ---- Write HIGH on DIO0_P ----
+  rp.scpi("DIG:PIN DIO0_P,1");
+  delay(500);
+
+  // ---- Read DIO1_P ----
+  String state = rp.scpiQuery("DIG:PIN? DIO1_P");
+  Serial.print("DIO1_P reads: ");
+  Serial.println(state);
+
+  // ---- Write LOW on DIO0_P ----
+  rp.scpi("DIG:PIN DIO0_P,0");
+  delay(500);
+
+  // ---- Read again ----
+  state = rp.scpiQuery("DIG:PIN? DIO1_P");
+  Serial.print("DIO1_P reads: ");
+  Serial.println(state);
+}

--- a/examples/Wifi/GPIOToggleWifi/arduino_secrets.h
+++ b/examples/Wifi/GPIOToggleWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/GenSineWifi/GenSineWifi.ino
+++ b/examples/Wifi/GenSineWifi/GenSineWifi.ino
@@ -1,0 +1,55 @@
+/* UNO R4 WiFi → Red Pitaya: generate a sine on OUT1 (SCPI)
+   Sends: GEN:RST; SOUR1:FUNC SINE; FREQ/AMP/OFFS; OUTPUT1 ON; TRIG INT
+*/
+
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+// ---------- User config ----------
+
+// Sine parameters
+const float SINE_FREQ_HZ = 2000.0; // frequency
+const float SINE_AMPL_V  = 1.0;    // amplitude (volts)
+const float SINE_OFFS_V  = 0.0;    // DC offset (volts)
+// ---------------------------------
+
+WifiSCPI rp;
+
+void genSineOut1(float freq_hz, float ampl_v, float offs_v) {
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi(String("SOUR1:FREQ:FIX ") + String(freq_hz, 6));
+  rp.scpi(String("SOUR1:VOLT ")     + String(ampl_v, 6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ")+ String(offs_v, 6));
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:INT");
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  // Generate sine on OUT1
+  genSineOut1(SINE_FREQ_HZ, SINE_AMPL_V, SINE_OFFS_V);
+  Serial.println("Sine started on OUT1.");
+}
+
+void loop() {
+  // Keep connection alive (optional)
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT);
+  delay(500);
+}
+
+// Optional helper to stop output (call once if you want to turn it off)
+void stopOutput1() {
+  rp.scpi("OUTPUT1:STATE OFF");
+  // or: rp.scpi("GEN:RST");
+}
+

--- a/examples/Wifi/GenSineWifi/arduino_secrets.h
+++ b/examples/Wifi/GenSineWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/LEDsWifi/LEDsPattern.ino
+++ b/examples/Wifi/LEDsWifi/LEDsPattern.ino
@@ -1,0 +1,33 @@
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+WifiSCPI rp;
+
+void setup() {
+  // Connect to WiFi and Red Pitaya
+  rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT);
+
+  // Set all LEDs as outputs
+  for (int i = 0; i < 8; i++) {
+    rp.scpi(String("DIG:PIN:DIR LED") + String(i) + ",OUT");
+  }
+}
+
+void loop() {
+  // Run through LEDs 0 → 7
+  for (int i = 0; i < 8; i++) {
+    // Turn ON LED i
+    rp.scpi(String("DIG:PIN LED") + String(i) + ",1");
+    delay(200);
+
+    // Turn OFF LED i
+    rp.scpi(String("DIG:PIN LED") + String(i) + ",0");
+  }
+
+  // (Optional) run backwards 7 → 0 for a "ping-pong" effect
+  for (int i = 6; i > 0; i--) {
+    rp.scpi(String("DIG:PIN LED") + String(i) + ",1");
+    delay(200);
+    rp.scpi(String("DIG:PIN LED") + String(i) + ",0");
+  }
+}

--- a/examples/Wifi/LEDsWifi/LEDsWifi.ino
+++ b/examples/Wifi/LEDsWifi/LEDsWifi.ino
@@ -1,0 +1,22 @@
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+WifiSCPI rp;
+
+void setup() {
+  // Connect to WiFi and Red Pitaya
+  rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT);
+
+  // Set LED0 as output
+  rp.scpi("DIG:PIN:DIR LED0,OUT");
+}
+
+void loop() {
+  // Turn LED0 ON
+  rp.scpi("DIG:PIN LED0,1");
+  delay(500);
+
+  // Turn LED0 OFF
+  rp.scpi("DIG:PIN LED0,0");
+  delay(500);
+}

--- a/examples/Wifi/LEDsWifi/arduino_secrets.h
+++ b/examples/Wifi/LEDsWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/PWMWifi/PWMWifi.ino
+++ b/examples/Wifi/PWMWifi/PWMWifi.ino
@@ -1,0 +1,78 @@
+#include <WiFiS3.h>
+#include "SCPI_RP.h"
+#include "SCPI_WiFi.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+// ------- User config -------
+#define USE_STATIC_IP  1
+
+const float GEN_FREQ_HZ   = 2000.0;
+const float GEN_AMPL_V    = 1.0;
+const float GEN_OFFSET_V  = 0.0;
+
+#if USE_STATIC_IP
+  IPAddress LOCAL_IP(192,168,0,50);
+  IPAddress GATEWAY (192,168,0,1);
+  IPAddress SUBNET  (255,255,255,0);
+  IPAddress DNS     (8,8,8,8);
+#endif
+// ---------------------------
+
+scpi_rp::SCPI_WiFi net;          // << new
+scpi_rp::SCPIRedPitaya rp;
+bool rpReady = false;
+
+// (optional) keep these if you like:
+void scpiSend(const String& s) { net.send(s); }
+String scpiQueryLine(const String& s, unsigned long t=2000) { return net.queryLine(s,t); }
+String scpiQueryAsciiBlock(const String& s, unsigned long t=8000) { return net.queryAsciiBlock(s,t); }
+
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+
+  Serial.print("WiFi connecting to "); Serial.println(SECRET_SSID);
+
+  scpi_rp::WiFiConfig cfg;
+#if USE_STATIC_IP
+  cfg.useStaticIP = true;
+  cfg.localIP = LOCAL_IP; cfg.gateway = GATEWAY; cfg.subnet = SUBNET; cfg.dns = DNS;
+#endif
+
+  if (!net.connectWiFi(SECRET_SSID, SECRET_PASS, &cfg)) {
+    Serial.println("❌ WiFi failed");
+    while (true) delay(1000);
+  }
+  Serial.print("✅ WiFi OK, IP = "); Serial.println(net.localIP());
+
+  if (!net.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) {
+    Serial.println("❌ TCP connect failed (will retry in loop)");
+  } else {
+    Serial.println("✅ TCP connected");
+    net.bind(rp);         // << bind SCPI to this socket (Stream)
+    rpReady = true;
+  }
+
+  // ... your LED init, genSineOut1(), and first acquire() as before
+}
+
+void loop() {
+  // Keep connections alive
+  if (!net.isWiFiUp() || !net.isRPUp()) {
+    scpi_rp::WiFiConfig cfg;
+#if USE_STATIC_IP
+    cfg.useStaticIP = true; cfg.localIP = LOCAL_IP; cfg.gateway = GATEWAY; cfg.subnet = SUBNET; cfg.dns = DNS;
+#endif
+    if (net.ensureConnections(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT, &cfg)) {
+      net.bind(rp);                 // re-bind after reconnect
+      rpReady = true;
+      // optionally re-start generator
+      // genSineOut1(GEN_FREQ_HZ, GEN_AMPL_V, GEN_OFFSET_V);
+    } else {
+      rpReady = false;
+    }
+  }
+
+  // ... keep your heartbeat + periodic acquisition exactly as before,
+  // but use net.send/query* helpers (already wired above).
+}

--- a/examples/Wifi/PWMWifi/arduino_secrets.h
+++ b/examples/Wifi/PWMWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/README.md
+++ b/examples/Wifi/README.md
@@ -1,0 +1,39 @@
+# Scpi
+
+## WifiSCPI helper
+
+`wifiSCPI.h` / `wifiSCPI.cpp` provide a small class that joins a Wi-Fi network, opens a TCP connection to the Red Pitaya SCPI server and exposes helpers for sending commands.
+
+### Using the helper in your sketch
+
+1. Copy `wifiSCPI.h` and `wifiSCPI.cpp` into your sketch folder (or install them as a library).
+2. Create an `arduino_secrets.h` with your WiFi credentials and Red Pitaya address:
+
+   ```cpp
+   #define SECRET_SSID "NetworkName"
+   #define SECRET_PASS "Password"
+   #define SECRET_RP_IP IPAddress(x, x, x, x)
+   #define SECRET_RP_PORT 5000
+   ```
+3. Include the headers and call `begin` with your Red Pitaya details:
+
+   ```cpp
+   #include "wifiSCPI.h"
+   #include "arduino_secrets.h"
+
+   WifiSCPI rp;
+
+   void setup() {
+     Serial.begin(115200);
+     rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT);
+
+     rp.scpi("ACQ:RST");
+     Serial.println(rp.scpiLine("*IDN?"));
+   }
+
+   void loop() {}
+   ```
+
+`begin` retries until both Wi-Fi and SCPI connections succeed. Use `scpi` to send a command without reading a response, `scpiLine` for single line replies, and `scpiBlock` for block data between `{}` braces. The underlying `WiFiClient` can be accessed via `client()` for streaming operations.
+
+Each example folder demonstrates a different Red Pitaya feature while leveraging this helper for network setup and SCPI communication.

--- a/examples/Wifi/SweepGenWifi/SweepGenWifi.ino
+++ b/examples/Wifi/SweepGenWifi/SweepGenWifi.ino
@@ -1,0 +1,64 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   OUT1 sweep using official sweep commands (no manual stepping)
+*/
+
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+// ------- User config -------
+
+// Output amplitude/offset
+const float AMP_V  = 1.0;           // one-way amplitude (V)
+const float OFFS_V = 0.0;           // DC offset (V)
+
+// Sweep config
+const float F_START_HZ = 1e3;       // start frequency (Hz)
+const float F_STOP_HZ  = 20e3;      // stop frequency (Hz)
+const unsigned long SWEEP_TIME_US = 3e6; // sweep time from start→stop, in microseconds
+const bool  LOG_SWEEP   = false;    // false=LINEAR, true=LOG
+const bool  PINGPONG    = true;     // true=UP_DOWN, false=NORMAL (up only)
+const bool  REPEAT_INF  = true;     // infinite repetitions (else one-shot)
+// ---------------------------
+
+WifiSCPI rp;
+
+void startSweep() {
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SWEEP");
+  rp.scpi(String("SOUR1:VOLT ") + String(AMP_V, 6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ") + String(OFFS_V, 6));
+  rp.scpi(String("SOUR1:SWeep:FREQ:START ") + String(F_START_HZ, 6));
+  rp.scpi(String("SOUR1:SWeep:FREQ:STOP ")  + String(F_STOP_HZ, 6));
+  rp.scpi(String("SOUR1:SWeep:TIME ")       + String((long)SWEEP_TIME_US));
+  rp.scpi(String("SOUR1:SWeep:MODE ") + (LOG_SWEEP ? "LOG" : "LINEAR"));
+  rp.scpi(String("SOUR1:SWeep:DIR ")  + (PINGPONG ? "UP_DOWN" : "NORMAL"));
+  if (REPEAT_INF) rp.scpi("SOUR1:SWeep:REP:INF ON");
+  else            rp.scpi("SOUR1:SWeep:REP:INF OFF");
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
+  rp.scpi("SOUR1:SWeep:STATE ON");
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  startSweep();
+  Serial.println("Sweep running on OUT1.");
+}
+
+void loop() {
+  // Optional keep-alive / auto-restart
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startSweep();
+  }
+  delay(500);
+}
+

--- a/examples/Wifi/SweepGenWifi/arduino_secrets.h
+++ b/examples/Wifi/SweepGenWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/2ChannelPhaseShiftWifi/2ChannelPhaseShiftWifi.ino
+++ b/src/Wifi/2ChannelPhaseShiftWifi/2ChannelPhaseShiftWifi.ino
@@ -1,0 +1,63 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   Two-channel sine with a fixed phase shift
+   - OUT1: sine @ FREQ_HZ, PHASE=0°
+   - OUT2: sine @ FREQ_HZ, PHASE=PHASE_DEG
+   Uses: SOUR<n>:PHAS, OUTPUT:STATE ON, SOUR:TRig:INT
+*/
+
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+// -------- User config --------
+
+const float FREQ_HZ   = 10000.0;  // both channels
+const float AMP_V     = 1.0;      // one-way amplitude
+const float OFFS_V    = 0.0;      // DC offset
+const float PHASE_DEG = 90.0;     // OUT2 phase relative to OUT1
+/* ---------------------------- */
+
+WifiSCPI rp;
+
+void startTwoSineWithPhase() {
+  rp.scpi("GEN:RST");
+
+  // Configure OUT1
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi(String("SOUR1:FREQ:FIX ") + String(FREQ_HZ, 6));
+  rp.scpi(String("SOUR1:VOLT ")     + String(AMP_V, 6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ")+ String(OFFS_V, 6));
+  rp.scpi("SOUR1:PHAS 0");
+
+  // Configure OUT2 (same freq/amp, shifted phase)
+  rp.scpi("SOUR2:FUNC SINE");
+  rp.scpi(String("SOUR2:FREQ:FIX ") + String(FREQ_HZ, 6));
+  rp.scpi(String("SOUR2:VOLT ")     + String(AMP_V, 6));
+  rp.scpi(String("SOUR2:VOLT:OFFS ")+ String(OFFS_V, 6));
+  rp.scpi(String("SOUR2:PHAS ")     + String(PHASE_DEG, 6));
+
+  rp.scpi("OUTPUT:STATE ON");
+  rp.scpi("SOUR:TRig:INT");
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  startTwoSineWithPhase();
+  Serial.println("Two-channel sine with phase shift is running.");
+}
+
+void loop() {
+  // Optional keep-alive / auto-restart
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startTwoSineWithPhase();
+  }
+  delay(500);
+}
+

--- a/src/Wifi/2ChannelPhaseShiftWifi/arduino_secrets.h
+++ b/src/Wifi/2ChannelPhaseShiftWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/AcquiireWifi/arduino_secrets.h
+++ b/src/Wifi/AcquiireWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/AcquireNowRawWifi/AcquireNowRawWifi.ino
+++ b/src/Wifi/AcquireNowRawWifi/AcquireNowRawWifi.ino
@@ -1,0 +1,46 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   acquire_full_buffer_raw: force trigger and read full buffer as RAW ASCII codes
+*/
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+
+WifiSCPI rp;
+
+void printFirst(const String& blk, uint8_t n=12){
+  int l=blk.indexOf('{'), r=blk.lastIndexOf('}');
+  if(l<0||r<=l){ Serial.println(blk); return; }
+  String b=blk.substring(l+1,r);
+  int st=0,c=0;
+  Serial.println(F("First RAW samples:"));
+  while(c<n){
+    int k=b.indexOf(',',st);
+    String t=(k==-1)?b.substring(st):b.substring(st,k);
+    t.trim();
+    if(t.length()){ Serial.println(t); c++; }
+    if(k==-1) break;
+    st=k+1;
+  }
+}
+
+void setup(){
+  Serial.begin(115200);
+  delay(200);
+  rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT);
+
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:DEC:Factor 1");
+  rp.scpi("ACQ:DATA:FORMAT ASCII");
+  rp.scpi("ACQ:DATA:UNITS RAW");   // ADC codes
+  rp.scpi("ACQ:TRig:DLY 0");
+
+  rp.scpi("ACQ:START");
+  delay(300);
+  rp.scpi("ACQ:TRig NOW");
+
+  while(rp.scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
+  printFirst(rp.scpiBlock("ACQ:SOUR1:DATA?"));
+  Serial.println("Done.");
+}
+
+void loop(){}

--- a/src/Wifi/AcquireNowRawWifi/arduino_secrets.h
+++ b/src/Wifi/AcquireNowRawWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/AcquireNowWifi/AcquireNowWifi.ino
+++ b/src/Wifi/AcquireNowWifi/AcquireNowWifi.ino
@@ -1,0 +1,38 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   acquire_trigger_now: force trigger and read CH1 (ASCII/VOLTS)
+*/
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+
+WifiSCPI rp;
+
+void printFirst(const String& blk, uint8_t n=12){
+  int l=blk.indexOf('{'), r=blk.lastIndexOf('}'); if(l<0||r<=l){ Serial.println(blk); return; }
+  String b=blk.substring(l+1,r); int st=0,c=0; Serial.println(F("First samples:"));
+  while(c<n){ int k=b.indexOf(',',st); String t=(k==-1)?b.substring(st):b.substring(st,k); t.trim();
+    if(t.length()){ Serial.println(t); c++; } if(k==-1) break; st=k+1; }
+}
+
+void setup(){
+  Serial.begin(115200); delay(200);
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:DEC:Factor 128");
+  rp.scpi("ACQ:DATA:FORMAT VOLTS");
+  rp.scpi("ACQ:DATA:UNITS ASCII");
+  rp.scpi("ACQ:TRig:DLY 0");
+  rp.scpi("ACQ:START");
+  delay(300);
+  rp.scpi("ACQ:TRig NOW");
+
+  while(rp.scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
+  printFirst(rp.scpiBlock("ACQ:SOUR1:DATA?"));
+  Serial.println("Done.");
+}
+
+void loop(){ }

--- a/src/Wifi/AcquireNowWifi/arduino_secrets.h
+++ b/src/Wifi/AcquireNowWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/AcquireTriggerFromGenWifi/AcquireTriggerFromGenWifi.ino
+++ b/src/Wifi/AcquireTriggerFromGenWifi/AcquireTriggerFromGenWifi.ino
@@ -1,0 +1,54 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   acquire_trigger_from_generator:
+   - start a sine on OUT1
+   - arm acquisition on AWG trigger (AWG_PE)
+   - fire generator INT trigger to produce the edge
+*/
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+
+WifiSCPI rp;
+
+void printFirst(const String& blk, uint8_t n=12){
+  int l=blk.indexOf('{'), r=blk.lastIndexOf('}'); if(l<0||r<=l){ Serial.println(blk); return; }
+  String b=blk.substring(l+1,r); int st=0,c=0; Serial.println(F("First samples:"));
+  while(c<n){ int k=b.indexOf(',',st); String t=(k==-1)?b.substring(st):b.substring(st,k); t.trim();
+    if(t.length()){ Serial.println(t); c++; } if(k==-1) break; st=k+1; }
+}
+
+void setup(){
+  Serial.begin(115200); delay(200);
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  // Generator: small sine on OUT1
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi("SOUR1:FREQ:FIX 10000");
+  rp.scpi("SOUR1:VOLT 0.5");
+  rp.scpi("SOUR1:VOLT:OFFS 0");
+  rp.scpi("OUTPUT1:STATE ON");
+
+  // Acquisition waiting for AWG trigger
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:DEC:Factor 1");
+  rp.scpi("ACQ:DATA:FORMAT VOLTS");
+  rp.scpi("ACQ:DATA:UNITS ASCII");
+  rp.scpi("ACQ:TRig:DLY 0");
+  rp.scpi("ACQ:START");
+  rp.scpi("ACQ:TRig AWG_PE");
+
+  // Fire AWG INT trigger
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
+
+  while(rp.scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
+  printFirst(rp.scpiBlock("ACQ:SOUR1:DATA?"));
+  Serial.println("Done.");
+}
+
+void loop(){ }
+

--- a/src/Wifi/AcquireTriggerFromGenWifi/arduino_secrets.h
+++ b/src/Wifi/AcquireTriggerFromGenWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/AnalogReadWifi/AnalogReadWifi.ino
+++ b/src/Wifi/AnalogReadWifi/AnalogReadWifi.ino
@@ -1,0 +1,75 @@
+/*  UNO R4 WiFi → Red Pitaya (SCPI)
+    - OUT1 arbitrary waveform = sum of 3 sines
+    - Fast, chunked upload (default 2048 points)
+*/
+
+#include "wifiSCPI.h"
+#include <math.h>
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+
+int   ARB_NPTS     = 2048;
+float F0_HZ        = 1000.0;
+float AMP1 = 1.0f, AMP2 = 0.6f, AMP3 = 0.3f;
+int   K1 = 1, K2 = 2, K3 = 5;
+float P1 = 0.0f, P2 = 0.0f, P3 = 0.0f;
+float ARB_AMPL_V   = 1.0f;
+float ARB_OFFS_V   = 0.0f;
+
+WifiSCPI rp;
+
+float sum3sines_norm(int i, int N) {
+  float t = 2.0f * (float)M_PI * (float)i / (float)N;
+  float x = 0.0f;
+  x += AMP1 * sinf(K1 * t + P1);
+  x += AMP2 * sinf(K2 * t + P2);
+  x += AMP3 * sinf(K3 * t + P3);
+  float S = fabsf(AMP1) + fabsf(AMP2) + fabsf(AMP3);
+  if (S < 1e-9f) S = 1.0f;
+  x /= S;
+  if (x > 1.0f) x = 1.0f;
+  if (x < -1.0f) x = -1.0f;
+  return x;
+}
+
+bool uploadSum3SinesOut1(int N) {
+  if (!rp.connected()) return false;
+  rp.scpi("GEN:RST");
+  rp.scpi("OUTPUT1:STATE OFF");
+  rp.scpi("SOUR1:FUNC ARBITRARY");
+  rp.client().print("SOUR1:TRAC:DATA:DATA ");
+  const int chunk = 256;
+  for (int i = 0; i < N; ++i) {
+    if (i) rp.client().print(",");
+    rp.client().print(sum3sines_norm(i, N), 6);
+  }
+  rp.client().print("\r\n");
+  float freq_set = F0_HZ * (16384.0f / (float)N);
+  rp.client().print("SOUR1:FREQ:FIX ");  rp.client().print(freq_set, 6);     rp.client().print("\r\n");
+  rp.client().print("SOUR1:VOLT ");      rp.client().print(ARB_AMPL_V, 6);   rp.client().print("\r\n");
+  rp.client().print("SOUR1:VOLT:OFFS "); rp.client().print(ARB_OFFS_V, 6);   rp.client().print("\r\n");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:INT");
+  return true;
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)) {
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+  uploadSum3SinesOut1(ARB_NPTS);
+  Serial.println("Sum-of-3-sines running on OUT1.");
+}
+
+void loop() {
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) uploadSum3SinesOut1(ARB_NPTS);
+  }
+  delay(500);
+}
+

--- a/src/Wifi/AnalogReadWifi/arduino_secrets.h
+++ b/src/Wifi/AnalogReadWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/ArbSignalWifi/ArbSignalWifi.ino
+++ b/src/Wifi/ArbSignalWifi/ArbSignalWifi.ino
@@ -1,0 +1,107 @@
+/*  UNO R4 WiFi → Red Pitaya (SCPI)
+    - OUT1 arbitrary waveform = sum of 3 sines
+    - Fast, chunked upload (default 2048 points)
+    - No acquisition, no LEDs — just ARB gen
+*/
+
+#include "wifiSCPI.h"
+#include <math.h>
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+/************ User Config ************/
+// Red Pitaya SCPI server
+
+// ARB buffer size (use 2048 for speed; 16384 is the full period size)
+int   ARB_NPTS     = 2048;
+
+// Base output frequency (Hz). The three tones will be
+// k1*f0, k2*f0, k3*f0 to make a seamless periodic waveform.
+float F0_HZ        = 1000.0;   // "fundamental" frequency
+
+// Amplitudes of the 3 sines (renamed to avoid conflict with A1/A2/A3 pin names)
+float AMP1 = 1.0f,  AMP2 = 0.6f,  AMP3 = 0.3f;
+
+// Harmonic bins (integers). Output tones = k*F0_HZ.
+int   K1 = 1,       K2 = 2,       K3 = 5;
+
+// Optional phases (radians)
+float P1 = 0.0f,    P2 = 0.0f,    P3 = 0.0f;
+
+// Analog output settings
+float ARB_AMPL_V   = 1.0f;     // amplitude (Volts)
+float ARB_OFFS_V   = 0.0f;     // DC offset (Volts)
+/************************************/
+
+WifiSCPI rp;
+
+/* ---------- Waveform: sum of 3 sines, normalized to [-1..+1] ---------- */
+float sum3sines_norm(int i, int N) {
+  float t = 2.0f * (float)M_PI * (float)i / (float)N;
+  float x = 0.0f;
+  x += AMP1 * sinf(K1 * t + P1);
+  x += AMP2 * sinf(K2 * t + P2);
+  x += AMP3 * sinf(K3 * t + P3);
+  float S = fabsf(AMP1) + fabsf(AMP2) + fabsf(AMP3);
+  if (S < 1e-9f) S = 1.0f;
+  x /= S;
+  if (x > 1.0f) x = 1.0f;
+  if (x < -1.0f) x = -1.0f;
+  return x;
+}
+
+/* ---------- Upload ARB (chunked), configure, and run ---------- */
+bool uploadSum3SinesOut1(int N) {
+  if (!rp.connected()) return false;
+
+  Serial.print("Uploading ARB (N="); Serial.print(N); Serial.print(") ... ");
+
+  rp.scpi("GEN:RST");
+  rp.scpi("OUTPUT1:STATE OFF");
+  rp.scpi("SOUR1:FUNC ARBITRARY");
+
+  rp.client().print("SOUR1:TRAC:DATA:DATA ");
+  const int chunk = 256;
+  for (int i = 0; i < N; ++i) {
+    if (i) rp.client().print(",");
+    rp.client().print(sum3sines_norm(i, N), 6);
+    if ((i % chunk) == 0) Serial.print(".");
+  }
+  rp.client().print("\r\n");
+  Serial.println(" done");
+
+  float freq_set = F0_HZ * (16384.0f / (float)N);
+
+  rp.client().print("SOUR1:FREQ:FIX ");  rp.client().print(freq_set, 6);     rp.client().print("\r\n");
+  rp.client().print("SOUR1:VOLT ");      rp.client().print(ARB_AMPL_V, 6);   rp.client().print("\r\n");
+  rp.client().print("SOUR1:VOLT:OFFS "); rp.client().print(ARB_OFFS_V, 6);   rp.client().print("\r\n");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:INT");
+  return true;
+}
+
+/* ---------- Arduino ---------- */
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  // Upload and start the 3-sine sum on OUT1
+  uploadSum3SinesOut1(ARB_NPTS);
+
+  Serial.println("Sum-of-3-sines running on OUT1.");
+}
+
+void loop() {
+  // Keep the link healthy (optional)
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) uploadSum3SinesOut1(ARB_NPTS); // re-arm after reconnect
+  }
+  delay(500);
+}
+

--- a/src/Wifi/ArbSignalWifi/arduino_secrets.h
+++ b/src/Wifi/ArbSignalWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/BurstSignalWifi/BurstSignalWifi.ino
+++ b/src/Wifi/BurstSignalWifi/BurstSignalWifi.ino
@@ -1,0 +1,77 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   Sine burst on OUT1 using official burst commands
+
+   Flow:
+     GEN:RST
+     SOUR1:FUNC SINE
+     SOUR1:FREQ:FIX <Hz>
+     SOUR1:VOLT <V>; SOUR1:VOLT:OFFS <V>
+     SOUR1:BURS:STAT BURST
+     SOUR1:BURS:NCYC <Ncycles>
+     SOUR1:BURS:NOR  <Repetitions>   (65536 == infinite)
+     SOUR1:BURS:INT:PER <Period_us>
+     OUTPUT1:STATE ON
+     SOUR1:TRig:SOUR INT
+     SOUR1:TRig:INT
+*/
+
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+// ---------- User config ----------
+
+// Signal settings
+const float FREQ_HZ   = 10e3;       // sine frequency
+const float AMP_V     = 0.8;        // one-way amplitude (V). |AMP|+|OFFS| ≤ 1 V on most RP models
+const float OFFS_V    = 0.0;        // DC offset (V)
+
+// Burst settings
+const uint32_t NCYCLES      = 5;        // number of sine periods in one burst
+const uint32_t REPETITIONS  = 10;       // number of bursts (65536 == infinite)
+const uint32_t PERIOD_US    = 100000;   // time from start-of-burst to start-of-next (µs)
+// ----------------------------------
+
+WifiSCPI rp;
+
+void startBurst() {
+  // Reset & basic sine settings
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi(String("SOUR1:FREQ:FIX ") + String(FREQ_HZ, 6));
+  rp.scpi(String("SOUR1:VOLT ")     + String(AMP_V,   6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ")+ String(OFFS_V,  6));
+
+  // --- Burst mode (official commands) ---
+  rp.scpi("SOUR1:BURS:STAT BURST");
+  rp.scpi(String("SOUR1:BURS:NCYC ") + String(NCYCLES));
+  rp.scpi(String("SOUR1:BURS:NOR ")  + String(REPETITIONS));
+  rp.scpi(String("SOUR1:BURS:INT:PER ") + String(PERIOD_US));
+
+  // Output + trigger
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  startBurst();
+  Serial.println("Burst started on OUT1.");
+}
+
+void loop() {
+  // Optional keep-alive
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startBurst();
+  }
+  delay(500);
+}
+

--- a/src/Wifi/BurstSignalWifi/arduino_secrets.h
+++ b/src/Wifi/BurstSignalWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/DMAAcquireWifi/DMAAcquireNowWifi.ino
+++ b/src/Wifi/DMAAcquireWifi/DMAAcquireNowWifi.ino
@@ -1,0 +1,53 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   dma/acquire_dma_trigger_now: set AXI DMA, trigger NOW, read 1024 samples near trig (ASCII)
+*/
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+
+WifiSCPI rp;
+
+/* helpers */
+void printFirst(const String& blk, uint8_t n=12){
+  int l=blk.indexOf('{'), r=blk.lastIndexOf('}'); if(l<0||r<=l){ Serial.println(blk); return; }
+  String b=blk.substring(l+1,r); int st=0,c=0; Serial.println(F("First DMA samples:"));
+  while(c<n){ int k=b.indexOf(',',st); String t=(k==-1)?b.substring(st):b.substring(st,k); t.trim();
+    if(t.length()){ Serial.println(t); c++; } if(k==-1) break; st=k+1; }
+}
+
+void setup(){
+  Serial.begin(115200); delay(200);
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  uint32_t axiStart = rp.scpiLine("ACQ:AXI:START?").toInt();
+  uint32_t axiSize  = rp.scpiLine("ACQ:AXI:SIZE?").toInt();
+  (void)axiStart; (void)axiSize;
+
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:AXI:DEC 1");
+  rp.scpi("ACQ:AXI:DATA:UNITS VOLTS");
+  rp.scpi("ACQ:DATA:FORMAT ASCII");
+  rp.scpi(String("ACQ:AXI:SOUR1:SET:Buffer ")+axiStart+","+axiSize);
+  rp.scpi("ACQ:AXI:SOUR1:ENable ON");
+  rp.scpi("ACQ:AXI:SOUR1:Trig:Dly 0");
+
+  rp.scpi("ACQ:START");
+  rp.scpi("ACQ:TRig NOW");
+
+  while(rp.scpiLine("ACQ:TRig:STAT?")!="TD") delay(10);
+  while(rp.scpiLine("ACQ:AXI:SOUR1:TRIG:FILL?")!="1") delay(10);
+
+  uint32_t pos = rp.scpiLine("ACQ:AXI:SOUR1:Trig:Pos?").toInt();
+  String cmd = String("ACQ:AXI:SOUR1:DATA:Start:N? ")+pos+",1024";
+  printFirst(rp.scpiBlock(cmd));
+
+  rp.scpi("ACQ:STOP");
+  rp.scpi("ACQ:AXI:SOUR1:ENable OFF");
+  Serial.println("Done.");
+}
+
+void loop(){ }
+

--- a/src/Wifi/DMAAcquireWifi/DMAAcquireWifi.ino
+++ b/src/Wifi/DMAAcquireWifi/DMAAcquireWifi.ino
@@ -1,0 +1,54 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   DMA acquire triggered by generator:
+   - start a sine on OUT1
+   - arm acquisition on AWG trigger (AWG_PE)
+   - fire generator INT trigger to produce the edge
+*/
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+
+WifiSCPI rp;
+
+void printFirst(const String& blk, uint8_t n=12){
+  int l=blk.indexOf('{'), r=blk.lastIndexOf('}'); if(l<0||r<=l){ Serial.println(blk); return; }
+  String b=blk.substring(l+1,r); int st=0,c=0; Serial.println(F("First samples:"));
+  while(c<n){ int k=b.indexOf(',',st); String t=(k==-1)?b.substring(st):b.substring(st,k); t.trim();
+    if(t.length()){ Serial.println(t); c++; } if(k==-1) break; st=k+1; }
+}
+
+void setup(){
+  Serial.begin(115200); delay(200);
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  // Generator: small sine on OUT1
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi("SOUR1:FREQ:FIX 10000");
+  rp.scpi("SOUR1:VOLT 0.5");
+  rp.scpi("SOUR1:VOLT:OFFS 0");
+  rp.scpi("OUTPUT1:STATE ON");
+
+  // Acquisition waiting for AWG trigger
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:DEC:Factor 1");
+  rp.scpi("ACQ:DATA:FORMAT VOLTS");
+  rp.scpi("ACQ:DATA:UNITS ASCII");
+  rp.scpi("ACQ:TRig:DLY 0");
+  rp.scpi("ACQ:START");
+  rp.scpi("ACQ:TRig AWG_PE");
+
+  // Fire AWG INT trigger
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
+
+  while(rp.scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
+  printFirst(rp.scpiBlock("ACQ:SOUR1:DATA?"));
+  Serial.println("Done.");
+}
+
+void loop(){ }
+

--- a/src/Wifi/DMAAcquireWifi/arduino_secrets.h
+++ b/src/Wifi/DMAAcquireWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/GPIOToggleWifi/GPIOToggleWifi.ino
+++ b/src/Wifi/GPIOToggleWifi/GPIOToggleWifi.ino
@@ -1,0 +1,48 @@
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+// ---------- User config ----------
+// ---------------------------------
+
+WifiSCPI rp;
+
+// --- GPIO pins ---
+const char* OUT_PIN = "DIO0_P";
+const char* IN_PIN  = "DIO1_P";
+
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  rp.scpi(String("DIG:PIN:DIR OUT,") + OUT_PIN);
+  rp.scpi(String("DIG:PIN:DIR IN,")  + IN_PIN);
+
+  Serial.print(OUT_PIN); Serial.print(" dir="); Serial.println(rp.scpiLine(String("DIG:PIN:DIR? ")+OUT_PIN));
+  Serial.print(IN_PIN);  Serial.print(" dir="); Serial.println(rp.scpiLine(String("DIG:PIN:DIR? ")+IN_PIN));
+}
+
+void loop() {
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) {
+      rp.scpi(String("DIG:PIN:DIR OUT,") + OUT_PIN);
+      rp.scpi(String("DIG:PIN:DIR IN,")  + IN_PIN);
+    }
+  }
+  if (!rp.connected()) { delay(200); return; }
+
+  static bool level = false;
+  rp.scpi(String("DIG:PIN ") + OUT_PIN + "," + (level ? "1" : "0"));
+  level = !level;
+
+  String v = rp.scpiLine(String("DIG:PIN? ") + IN_PIN);
+  Serial.print(IN_PIN); Serial.print(" = "); Serial.println(v);
+
+  delay(200);
+}
+

--- a/src/Wifi/GPIOToggleWifi/arduino_secrets.h
+++ b/src/Wifi/GPIOToggleWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/GenSineWifi/GenSineWifi.ino
+++ b/src/Wifi/GenSineWifi/GenSineWifi.ino
@@ -1,0 +1,55 @@
+/* UNO R4 WiFi → Red Pitaya: generate a sine on OUT1 (SCPI)
+   Sends: GEN:RST; SOUR1:FUNC SINE; FREQ/AMP/OFFS; OUTPUT1 ON; TRIG INT
+*/
+
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+// ---------- User config ----------
+
+// Sine parameters
+const float SINE_FREQ_HZ = 2000.0; // frequency
+const float SINE_AMPL_V  = 1.0;    // amplitude (volts)
+const float SINE_OFFS_V  = 0.0;    // DC offset (volts)
+// ---------------------------------
+
+WifiSCPI rp;
+
+void genSineOut1(float freq_hz, float ampl_v, float offs_v) {
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi(String("SOUR1:FREQ:FIX ") + String(freq_hz, 6));
+  rp.scpi(String("SOUR1:VOLT ")     + String(ampl_v, 6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ")+ String(offs_v, 6));
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:INT");
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  // Generate sine on OUT1
+  genSineOut1(SINE_FREQ_HZ, SINE_AMPL_V, SINE_OFFS_V);
+  Serial.println("Sine started on OUT1.");
+}
+
+void loop() {
+  // Keep connection alive (optional)
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT);
+  delay(500);
+}
+
+// Optional helper to stop output (call once if you want to turn it off)
+void stopOutput1() {
+  rp.scpi("OUTPUT1:STATE OFF");
+  // or: rp.scpi("GEN:RST");
+}
+

--- a/src/Wifi/GenSineWifi/arduino_secrets.h
+++ b/src/Wifi/GenSineWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/LEDsWifi/LEDsWifi.ino
+++ b/src/Wifi/LEDsWifi/LEDsWifi.ino
@@ -1,0 +1,43 @@
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+// ------- User config -------
+
+const float GEN_FREQ_HZ   = 2000.0;
+const float GEN_AMPL_V    = 1.0;
+const float GEN_OFFSET_V  = 0.0;
+// ---------------------------
+
+WifiSCPI rp;
+
+void startGen() {
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi(String("SOUR1:FREQ:FIX ") + String(GEN_FREQ_HZ, 6));
+  rp.scpi(String("SOUR1:VOLT ")     + String(GEN_AMPL_V, 6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ")+ String(GEN_OFFSET_V, 6));
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  startGen();
+}
+
+void loop() {
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startGen();
+  }
+  delay(500);
+}
+

--- a/src/Wifi/LEDsWifi/arduino_secrets.h
+++ b/src/Wifi/LEDsWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/PWMWifi/PWMWifi.ino
+++ b/src/Wifi/PWMWifi/PWMWifi.ino
@@ -1,0 +1,52 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   Generate PWM on OUT1 with 30% duty
+   Uses official commands: SOUR1:FUNC PWM, SOUR1:DCYC <ratio>, FREQ/AMP/OFFS
+*/
+
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+// ----- User config -----
+
+const float PWM_FREQ_HZ = 1000.0;  // PWM frequency (Hz)
+const float PWM_DUTY    = 0.30;    // 30% duty (ratio 0..1)
+const float AMP_V       = 1.0;     // one-way amplitude (V)
+const float OFFS_V      = 0.0;     // DC offset (V)
+// -----------------------
+
+WifiSCPI rp;
+
+void startPWM() {
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC PWM");
+  rp.scpi(String("SOUR1:FREQ:FIX ") + String(PWM_FREQ_HZ, 6));
+  rp.scpi(String("SOUR1:VOLT ")     + String(AMP_V, 6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ")+ String(OFFS_V, 6));
+  rp.scpi(String("SOUR1:DCYC ")     + String(PWM_DUTY, 6));
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  startPWM();
+  Serial.println("PWM (30% duty) running on OUT1.");
+}
+
+void loop() {
+  // Optional keep-alive / auto-restart
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startPWM();
+  }
+  delay(500);
+}
+

--- a/src/Wifi/PWMWifi/arduino_secrets.h
+++ b/src/Wifi/PWMWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/README.md
+++ b/src/Wifi/README.md
@@ -1,0 +1,39 @@
+# Scpi
+
+## WifiSCPI helper
+
+`wifiSCPI.h` / `wifiSCPI.cpp` provide a small class that joins a Wi-Fi network, opens a TCP connection to the Red Pitaya SCPI server and exposes helpers for sending commands.
+
+### Using the helper in your sketch
+
+1. Copy `wifiSCPI.h` and `wifiSCPI.cpp` into your sketch folder (or install them as a library).
+2. Create an `arduino_secrets.h` with your WiFi credentials and Red Pitaya address:
+
+   ```cpp
+   #define SECRET_SSID "NetworkName"
+   #define SECRET_PASS "Password"
+   #define SECRET_RP_IP IPAddress(x, x, x, x)
+   #define SECRET_RP_PORT 5000
+   ```
+3. Include the headers and call `begin` with your Red Pitaya details:
+
+   ```cpp
+   #include "wifiSCPI.h"
+   #include "arduino_secrets.h"
+
+   WifiSCPI rp;
+
+   void setup() {
+     Serial.begin(115200);
+     rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT);
+
+     rp.scpi("ACQ:RST");
+     Serial.println(rp.scpiLine("*IDN?"));
+   }
+
+   void loop() {}
+   ```
+
+`begin` retries until both Wi-Fi and SCPI connections succeed. Use `scpi` to send a command without reading a response, `scpiLine` for single line replies, and `scpiBlock` for block data between `{}` braces. The underlying `WiFiClient` can be accessed via `client()` for streaming operations.
+
+Each example folder demonstrates a different Red Pitaya feature while leveraging this helper for network setup and SCPI communication.

--- a/src/Wifi/SweepGenWifi/SweepGenWifi.ino
+++ b/src/Wifi/SweepGenWifi/SweepGenWifi.ino
@@ -1,0 +1,64 @@
+/* UNO R4 WiFi → Red Pitaya (SCPI)
+   OUT1 sweep using official sweep commands (no manual stepping)
+*/
+
+#include "wifiSCPI.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
+
+// ------- User config -------
+
+// Output amplitude/offset
+const float AMP_V  = 1.0;           // one-way amplitude (V)
+const float OFFS_V = 0.0;           // DC offset (V)
+
+// Sweep config
+const float F_START_HZ = 1e3;       // start frequency (Hz)
+const float F_STOP_HZ  = 20e3;      // stop frequency (Hz)
+const unsigned long SWEEP_TIME_US = 3e6; // sweep time from start→stop, in microseconds
+const bool  LOG_SWEEP   = false;    // false=LINEAR, true=LOG
+const bool  PINGPONG    = true;     // true=UP_DOWN, false=NORMAL (up only)
+const bool  REPEAT_INF  = true;     // infinite repetitions (else one-shot)
+// ---------------------------
+
+WifiSCPI rp;
+
+void startSweep() {
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SWEEP");
+  rp.scpi(String("SOUR1:VOLT ") + String(AMP_V, 6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ") + String(OFFS_V, 6));
+  rp.scpi(String("SOUR1:SWeep:FREQ:START ") + String(F_START_HZ, 6));
+  rp.scpi(String("SOUR1:SWeep:FREQ:STOP ")  + String(F_STOP_HZ, 6));
+  rp.scpi(String("SOUR1:SWeep:TIME ")       + String((long)SWEEP_TIME_US));
+  rp.scpi(String("SOUR1:SWeep:MODE ") + (LOG_SWEEP ? "LOG" : "LINEAR"));
+  rp.scpi(String("SOUR1:SWeep:DIR ")  + (PINGPONG ? "UP_DOWN" : "NORMAL"));
+  if (REPEAT_INF) rp.scpi("SOUR1:SWeep:REP:INF ON");
+  else            rp.scpi("SOUR1:SWeep:REP:INF OFF");
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
+  rp.scpi("SOUR1:SWeep:STATE ON");
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(150);
+
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
+
+  startSweep();
+  Serial.println("Sweep running on OUT1.");
+}
+
+void loop() {
+  // Optional keep-alive / auto-restart
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startSweep();
+  }
+  delay(500);
+}
+

--- a/src/Wifi/SweepGenWifi/arduino_secrets.h
+++ b/src/Wifi/SweepGenWifi/arduino_secrets.h
@@ -1,0 +1,4 @@
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/wifiSCPI.cpp
+++ b/src/wifiSCPI.cpp
@@ -1,0 +1,81 @@
+#include "wifiSCPI.h"
+
+WifiSCPI::WifiSCPI() : _client() {}
+
+bool WifiSCPI::begin(const char* ssid, const char* pass, const IPAddress& ip, uint16_t port){
+  while(!connectWiFi(ssid, pass)) {
+    Serial.println(F("WiFi not ready, retrying..."));
+    delay(1000);
+  }
+  while(!connectRP(ip, port)) {
+    Serial.println(F("SCPI connection failed, retrying..."));
+    delay(1000);
+  }
+  return true;
+}
+
+bool WifiSCPI::connectWiFi(const char* ssid, const char* pass, unsigned long timeout){
+  WiFi.begin(ssid, pass);
+  unsigned long t0 = millis();
+  while(WiFi.status() != WL_CONNECTED && millis() - t0 < timeout) delay(250);
+  if(WiFi.status() != WL_CONNECTED) return false;
+  unsigned long t1 = millis();
+  while(WiFi.localIP() == IPAddress(0,0,0,0) && millis() - t1 < 3000) delay(50);
+  return true;
+}
+
+bool WifiSCPI::connectRP(const IPAddress& ip, uint16_t port){
+  if(_client.connected()) return true;
+  _client.stop();
+  return _client.connect(ip, port);
+}
+
+void WifiSCPI::scpiFlush(){
+  while(_client.available()) (void)_client.read();
+}
+
+void WifiSCPI::scpi(const String& s){
+  _client.print(s);
+  _client.print("\r\n");
+}
+
+String WifiSCPI::scpiLine(const String& s, unsigned long timeout){
+  scpiFlush();
+  scpi(s);
+  String r;
+  unsigned long t0 = millis();
+  while(millis() - t0 < timeout) {
+    while(_client.available()) {
+      char c = _client.read();
+      if(c == '\n') {
+        if(r.endsWith("\r")) r.remove(r.length()-1);
+        return r;
+      }
+      r += c;
+    }
+  }
+  return r;
+}
+
+String WifiSCPI::scpiBlock(const String& s, unsigned long timeout){
+  scpiFlush();
+  scpi(s);
+  String r;
+  bool in = false;
+  unsigned long t0 = millis();
+  while(millis() - t0 < timeout) {
+    while(_client.available()) {
+      char c = _client.read();
+      if(!in) {
+        if(c == '{') {
+          in = true;
+          r += c;
+        }
+        continue;
+      }
+      r += c;
+      if(c == '}') return r;
+    }
+  }
+  return r;
+}

--- a/src/wifiSCPI.h
+++ b/src/wifiSCPI.h
@@ -1,0 +1,21 @@
+#ifndef WIFI_SCPI_H
+#define WIFI_SCPI_H
+
+#include <WiFiS3.h>
+
+class WifiSCPI {
+public:
+  WifiSCPI();
+  bool begin(const char* ssid, const char* pass, const IPAddress& ip, uint16_t port = 5000);
+  bool connectWiFi(const char* ssid, const char* pass, unsigned long timeout = 30000);
+  bool connectRP(const IPAddress& ip, uint16_t port = 5000);
+  void scpi(const String& s);
+  String scpiLine(const String& s, unsigned long timeout = 3000);
+  String scpiBlock(const String& s, unsigned long timeout = 10000);
+  void scpiFlush();
+  bool connected() { return _client.connected(); }
+private:
+  WiFiClient _client;
+};
+
+#endif


### PR DESCRIPTION

# Wifi Update
--
Earlier versions of this library only supported SCPI communication over a
UART link. The new WiFi expansion adds `wifiSCPI.h` / `wifiSCPI.cpp`, a
lightweight wrapper that joins a Wi-Fi network, opens a TCP connection to
the Red Pitaya SCPI server and provides helpers for sending commands.
 
With this addition you can reuse the same SCPI commands previously sent
over UART while controlling the board wirelessly. Each example folder
demonstrates a different Red Pitaya feature while leveraging this helper
for network setup and SCPI communication.

